### PR TITLE
Emit STDERR for called commands.

### DIFF
--- a/dok8s-create
+++ b/dok8s-create
@@ -81,7 +81,7 @@ doctl -u "${API_ENDPOINT}" compute droplet create "${MASTER_NAME}" \
     --enable-ipv6 \
     --enable-monitoring \
     --user-data-file "${TEMP_DIR}"/master.sh \
-    --wait > /dev/null 2>&1
+    --wait > /dev/null
 
 # get the public/private ips of the master
 MASTER_ID=$(doctl -u "${API_ENDPOINT}" compute droplet list | grep "${MASTER_NAME}" |cut -d' ' -f1)
@@ -119,7 +119,7 @@ doctl -u "${API_ENDPOINT}" compute droplet create "${nodes[@]}" \
     --enable-ipv6 \
     --enable-monitoring \
     --user-data-file "${TEMP_DIR}"/node.sh \
-    --wait > /dev/null 2>&1
+    --wait > /dev/null
 
 echo "- Waiting nodes to be ready"
 # wait till nodes are ready
@@ -128,20 +128,20 @@ do
     sleep 10
 done
 
-kubectl create -f manifests/metrics-server > /dev/null 2>&1
+kubectl create -f manifests/metrics-server > /dev/null
 
-kubectl create namespace monitoring > /dev/null 2>&1
-kubectl create -n monitoring -f manifests/prometheus > /dev/null 2>&1
-kubectl create -n monitoring -f manifests/node-exporter > /dev/null 2>&1
-kubectl create -n monitoring -f manifests/grafana/ > /dev/null 2>&1
+kubectl create namespace monitoring > /dev/null
+kubectl create -n monitoring -f manifests/prometheus > /dev/null
+kubectl create -n monitoring -f manifests/node-exporter > /dev/null
+kubectl create -n monitoring -f manifests/grafana/ > /dev/null
 
-kubectl create namespace custom-metrics > /dev/null 2>&1
-openssl req -x509 -sha256 -new -nodes -days 365 -newkey rsa:2048 -keyout serving.key -out serving.crt -subj "/CN=ca" > /dev/null 2>&1
-kubectl create -n custom-metrics secret tls cm-adapter-serving-certs --cert=./serving.crt --key=./serving.key > /dev/null 2>&1
-kubectl create -f manifests/custom-metrics-apiserver > /dev/null 2>&1
+kubectl create namespace custom-metrics > /dev/null
+openssl req -x509 -sha256 -new -nodes -days 365 -newkey rsa:2048 -keyout serving.key -out serving.crt -subj "/CN=ca" > /dev/null
+kubectl create -n custom-metrics secret tls cm-adapter-serving-certs --cert=./serving.crt --key=./serving.key > /dev/null
+kubectl create -f manifests/custom-metrics-apiserver > /dev/null
 
 # set dashboard access to admin
-cat <<EOF | kubectl create -f - > /dev/null 2>&1
+cat <<EOF | kubectl create -f - > /dev/null
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -169,14 +169,14 @@ doctl -u "${API_ENDPOINT}" compute load-balancer create \
     --tag-name k8s-node \
     --region "${REGION}" \
     --health-check protocol:http,port:"${PROMPORT}",path:/graph,check_interval_seconds:10,response_timeout_seconds:5,healthy_threshold:5,unhealthy_threshold:3 \
-    --forwarding-rules entry_protocol:http,entry_port:"${PROMPORT}",target_protocol:http,target_port:"${PROMPORT}" > /dev/null 2>&1
+    --forwarding-rules entry_protocol:http,entry_port:"${PROMPORT}",target_protocol:http,target_port:"${PROMPORT}" > /dev/null
 
 echo "- Creating the master firewall"
 doctl -u "${API_ENDPOINT}" compute firewall create \
     --name k8s-master \
     --inbound-rules "protocol:tcp,ports:all,tag:k8s-node protocol:udp,ports:all,tag:k8s-node protocol:tcp,ports:22,address:0.0.0.0/0,address:::/0 protocol:tcp,ports:443,address:0.0.0.0/0,address:::/0" \
     --outbound-rules "protocol:icmp,address:0.0.0.0/0,address:::/0 protocol:tcp,ports:all,address:0.0.0.0/0,address:::/0 protocol:udp,ports:all,address:0.0.0.0/0,address:::/0" \
-    --tag-names k8s-master > /dev/null 2>&1
+    --tag-names k8s-master > /dev/null
 
 
 echo "- Creating the node firewall"
@@ -184,6 +184,6 @@ doctl -u "${API_ENDPOINT}" compute firewall create \
     --name k8s-nodes \
     --inbound-rules "protocol:tcp,ports:all,tag:k8s-master protocol:udp,ports:all,tag:k8s-master protocol:tcp,ports:all,tag:k8s-node protocol:udp,ports:all,tag:k8s-node protocol:tcp,ports:22,address:0.0.0.0/0,address:::/0 protocol:tcp,ports:${PROMPORT},address:0.0.0.0/0,address:::/0 protocol:tcp,ports:${GRAFPORT},address:0.0.0.0/0,address:::/0" \
     --outbound-rules "protocol:icmp,address:0.0.0.0/0,address:::/0 protocol:tcp,ports:all,address:0.0.0.0/0,address:::/0 protocol:udp,ports:all,address:0.0.0.0/0,address:::/0" \
-    --tag-names k8s-node > /dev/null 2>&1
+    --tag-names k8s-node > /dev/null
 
 echo "- Installation completed"


### PR DESCRIPTION
When `dok8s-create` fails, it's sometimes hard to identify the reason as most commands discard both STDOUT and STDERR. This PR changes the script to emit STDERR in order to improve debuggability.