### PR TITLE
Simplify droplet deletion.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Now access Dashboard at:
 To destroy the cluster:
 
 ```sh
-$ DIGITALOCEAN_ACCESS_TOKEN=XxX MASTER_NAME=master NODE_NAME=node NODE_COUNT=3 ./dok8s-destroy
+$ DIGITALOCEAN_ACCESS_TOKEN=XxX MASTER_NAME=master NODE_NAME=node ./dok8s-destroy
 - Destroying the droplets
 - Destroying the tags
 - Destroying the load balancer

--- a/dok8s-destroy
+++ b/dok8s-destroy
@@ -15,23 +15,20 @@ fi
 MASTER_NAME=${MASTER_NAME:-master}
 NODE_NAME=${NODE_NAME:-node}
 
-NODE_COUNT=${NODE_COUNT:-3}
-
 API_ENDPOINT=${API_ENDPOINT:-https://api.digitalocean.com/}
 
 echo "- Destroying the droplets"
 # delete the droplets
-MASTER_ID=$(doctl -u "${API_ENDPOINT}" compute droplet list | grep "${MASTER_NAME}" |cut -d' ' -f1)
-if [ -n "${MASTER_ID}" ]; then
-    doctl -u "${API_ENDPOINT}" compute droplet delete -f "${MASTER_ID}"
-fi
-
-for i in $(seq "${NODE_COUNT}"); do
-    NODE_ID=$(doctl -u "${API_ENDPOINT}" compute droplet list | grep "${NODE_NAME}""$i" |cut -d' ' -f1)
-    if [ -n "${NODE_ID}" ]; then
-        doctl -u "${API_ENDPOINT}" compute droplet delete -f "${NODE_ID}"
+NODES=()
+for TAG in k8s-master k8s-node; do
+    DROPLET="$(doctl -u "${API_ENDPOINT}" compute droplet list --format=ID --tag-name=${TAG} --no-header)"
+    if [ "${DROPLET}" ]; then
+        NODES+=("${DROPLET}")
     fi
 done
+if [ ${#NODES[@]} -gt 0 ]; then
+    doctl -u "${API_ENDPOINT}" compute droplet delete -f ${NODES[@]}
+fi
 
 echo "- Destroying the tags"
 # delete the tags


### PR DESCRIPTION
- Use tags and doctl options to fetch droplets.
- Delete droplets in a single API call.
- Remove obsoleted `NODE_COUNT` variable.